### PR TITLE
updated config for execute migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/nest",
-  "version": "1.7.31",
+  "version": "1.7.32",
   "scripts": {
     "script": "nps",
     "watch": "nps watch",

--- a/src/infrastructure/applications/console/config.ts
+++ b/src/infrastructure/applications/console/config.ts
@@ -1,5 +1,5 @@
 import {PostgresConnectionOptions} from '@steroidsjs/typeorm/driver/postgres/PostgresConnectionOptions';
-import {join} from 'path';
+import * as path from 'path';
 import * as fs from 'node:fs';
 import baseConfig from '../base/config';
 import {IConsoleAppModuleConfig} from './IConsoleAppModuleConfig';
@@ -7,14 +7,17 @@ import {EntityCodeGenerateCommand} from '../../commands/entity-generator/EntityC
 import {MigrateCommand} from '../../commands/MigrateCommand';
 import {CommandModule} from 'nestjs-command';
 
-/**
- * process.env.CLI_PATH is set in .gitlab-ci.yml
- */
-const sourceRoot = join(process.cwd(), process.env.CLI_PATH // TODO Use from nest-cli.json configuration?
-    ? 'dist'
-    : 'src',
-);
 const isMigrateCommand = !!(process.argv || []).find(arg => /^migrate/.exec(arg));
+
+// For deployment to use files in dist directory.
+const envRootDir = process.env.APP_ENVIRONMENT === 'dev' ? 'src' : 'dist';
+
+/**
+ * If CLI_PATH is specified then use directory from it.
+ */
+const migrationsRootDir = process.env.CLI_PATH && path.dirname(process.env.CLI_PATH)
+    ? path.dirname(process.env.CLI_PATH).split(path.sep).find(dir => !dir.includes('.'))
+    : envRootDir;
 
 export default {
     ...baseConfig,
@@ -25,7 +28,7 @@ export default {
             database: {
                 ...config.database,
                 migrations: isMigrateCommand
-                    ? fs.readdirSync(sourceRoot).map(name => join(sourceRoot, `${name}/infrastructure/migrations/*{.ts,.js}`))
+                    ? fs.readdirSync(migrationsRootDir).map(name => path.join(migrationsRootDir, `${name}/infrastructure/migrations/*{.ts,.js}`))
                     : [], // Do not include migrations on web and other cli commands
                 migrationsTableName: 'migrations',
             } as PostgresConnectionOptions

--- a/src/infrastructure/applications/console/config.ts
+++ b/src/infrastructure/applications/console/config.ts
@@ -7,7 +7,13 @@ import {EntityCodeGenerateCommand} from '../../commands/entity-generator/EntityC
 import {MigrateCommand} from '../../commands/MigrateCommand';
 import {CommandModule} from 'nestjs-command';
 
-const sourceRoot = join(process.cwd(), 'src'); // TODO Use from nest-cli.json configuration?
+/**
+ * process.env.CLI_PATH is set in .gitlab-ci.yml
+ */
+const sourceRoot = join(process.cwd(), process.env.CLI_PATH // TODO Use from nest-cli.json configuration?
+    ? 'dist'
+    : 'src',
+);
 const isMigrateCommand = !!(process.argv || []).find(arg => /^migrate/.exec(arg));
 
 export default {


### PR DESCRIPTION
Задача - https://gitlab.kozhindev.com/steroids/steroids-nest/-/issues/20

>Раньше миграции запускались с использованием dist-файлов следующим образом, но в какой-то момент этот метод запуска стал приводить к ошибкам.

```shell
CLI_PATH=./dist/cli.js bash -c 'npx nestjs-command migrate'
```

Потому что была попытка выполнить миграции из директории `src`
```js
const sourceRoot = join(process.cwd(), 'src');
```

задал использование директории в зависимости от того, задана ли переменная `CLI_PATH` или нет.