### PR TITLE
Fix circular dependencies RelationField swaggerType error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/nest",
-  "version": "1.7.36",
+  "version": "1.7.37",
   "scripts": {
     "script": "nps",
     "watch": "nps watch",

--- a/src/infrastructure/decorators/fields/BaseField.ts
+++ b/src/infrastructure/decorators/fields/BaseField.ts
@@ -42,7 +42,7 @@ export interface IRelationData {
 export interface IInternalFieldOptions {
     appType?: AppColumnType,
     jsType?: ColumnType,
-    swaggerType?: ColumnType,
+    swaggerType?: ColumnType | (() => ColumnType),
     decoratorName?: string,
     isArray?: boolean,
 }

--- a/src/infrastructure/decorators/fields/RelationField.ts
+++ b/src/infrastructure/decorators/fields/RelationField.ts
@@ -149,7 +149,7 @@ export function RelationField(options: IRelationFieldOptions) {
                 decoratorName: 'RelationField',
                 appType: 'relation',
                 jsType: 'number',
-                swaggerType: options.relationClass(),
+                swaggerType: options.relationClass,
                 isArray: ['ManyToMany', 'OneToMany'].includes(options.type),
             }),
             getRelationDecorator(options.type)(


### PR DESCRIPTION
Reason:
```
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
Error: A circular dependency has been detected (property key: "prop"). Please, make sure that each side of a bidirectional relationships are using lazy resolvers ("type: () => ClassType").
```

PropDependentModel.ts
```ts
@RelationField({
    type: 'ManyToOne',
    relationClass: () => PropModel,
})
prop: PropModel;
```

PropModel.ts
```ts
@RelationField({
    type: 'OneToMany',
    inverseSide: (dep: PropDependentModel) => dep.prop,
    relationClass: () => PropDependentModel,
})
deps: PropDependentModel[];
```