### PR TITLE
Typings fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/nest",
-  "version": "1.8.3",
+  "version": "2.0.0",
   "scripts": {
     "script": "nps",
     "watch": "nps watch",

--- a/src/infrastructure/repositories/CrudRepository.ts
+++ b/src/infrastructure/repositories/CrudRepository.ts
@@ -25,7 +25,7 @@ export class CrudRepository<TModel> implements ICrudRepository<TModel>, OnModule
     /**
      * TypeORM repository instance
      */
-    public dbRepository: Repository<any>;
+    protected dbRepository: Repository<any>;
 
     protected modelClass;
 

--- a/src/infrastructure/tests/ModelTest.test.ts
+++ b/src/infrastructure/tests/ModelTest.test.ts
@@ -55,11 +55,13 @@ describe('ModelTest', () => {
         expect(additionalPhoto?.id).toBeGreaterThan(0);
         expect(additionalPhoto?.imagesIds?.length).toEqual(1);
 
-        additionalPhoto = await app.get(FileService).findOne(
-            new SearchQuery()
-                .with(['imagesIds'])
-                .where({id: additionalPhoto.id})
-        );
+        additionalPhoto = await app
+            .get(FileService)
+            .findOne(
+                new SearchQuery()
+                    .with(['imagesIds'])
+                    .where({id: additionalPhoto.id})
+            );
 
         expect(additionalPhoto?.id).toBeGreaterThan(0);
         expect(additionalPhoto?.imagesIds?.length).toEqual(1);
@@ -139,11 +141,13 @@ describe('ModelTest', () => {
         expect(user?.galleryPhotosIds.length).toEqual(photos.length);
 
         // Get user from database with relations
-        user = await app.get(UserService).findOne(
-            new SearchQuery()
-                .with(['mainPhotoId', 'galleryPhotosIds', 'info'])
-                .where({id: user.id})
-        );
+        user = await app
+            .get(UserService)
+            .findOne(
+                new SearchQuery()
+                    .with(['mainPhotoId', 'galleryPhotosIds', 'info'])
+                    .where({id: user.id})
+            );
         expect(user?.id).toBeGreaterThan(0);
         expect(user?.mainPhotoId).toEqual(mainPhoto.id);
         expect(user?.info?.passport).toEqual('0409 123456');

--- a/src/infrastructure/tests/ModelTest.test.ts
+++ b/src/infrastructure/tests/ModelTest.test.ts
@@ -55,10 +55,12 @@ describe('ModelTest', () => {
         expect(additionalPhoto?.id).toBeGreaterThan(0);
         expect(additionalPhoto?.imagesIds?.length).toEqual(1);
 
-        additionalPhoto = await app.get(FileService).findOne(DataMapper.create(SearchQuery, {
-            relations: ['imagesIds'],
-            condition: {id: additionalPhoto.id},
-        }));
+        additionalPhoto = await app.get(FileService).findOne(
+            new SearchQuery()
+                .with(['imagesIds'])
+                .where({id: additionalPhoto.id})
+        );
+
         expect(additionalPhoto?.id).toBeGreaterThan(0);
         expect(additionalPhoto?.imagesIds?.length).toEqual(1);
     });
@@ -137,10 +139,11 @@ describe('ModelTest', () => {
         expect(user?.galleryPhotosIds.length).toEqual(photos.length);
 
         // Get user from database with relations
-        user = await app.get(UserService).findOne(DataMapper.create(SearchQuery, {
-            relations: ['mainPhotoId', 'galleryPhotosIds', 'info'],
-            condition: {id: user.id},
-        }));
+        user = await app.get(UserService).findOne(
+            new SearchQuery()
+                .with(['mainPhotoId', 'galleryPhotosIds', 'info'])
+                .where({id: user.id})
+        );
         expect(user?.id).toBeGreaterThan(0);
         expect(user?.mainPhotoId).toEqual(mainPhoto.id);
         expect(user?.info?.passport).toEqual('0409 123456');

--- a/src/usecases/helpers/DataMapper.ts
+++ b/src/usecases/helpers/DataMapper.ts
@@ -11,10 +11,11 @@ import {
 } from '../../infrastructure/decorators/Transform';
 import {getModelBuilder} from '../../infrastructure/decorators/TableFromModel';
 import {IType} from '../interfaces/IType';
+import {DeepPartial} from "@steroidsjs/typeorm";
 
 export class DataMapper {
 
-    static create<T>(MetaClass: IType<T>, values: Partial<T>, transformType: ITransformType = TRANSFORM_TYPE_DEFAULT, skipBuilder = false): T {
+    static create<T>(MetaClass: IType<T>, values: DeepPartial<T>, transformType: ITransformType = TRANSFORM_TYPE_DEFAULT, skipBuilder = false): T {
         // Check empty
         if (values === null) {
             return null;

--- a/src/usecases/helpers/DataMapper.ts
+++ b/src/usecases/helpers/DataMapper.ts
@@ -10,10 +10,11 @@ import {
     TRANSFORM_TYPE_DEFAULT
 } from '../../infrastructure/decorators/Transform';
 import {getModelBuilder} from '../../infrastructure/decorators/TableFromModel';
+import {IType} from '../interfaces/IType';
 
 export class DataMapper {
 
-    static create<T>(MetaClass, values: Partial<T>, transformType: ITransformType = TRANSFORM_TYPE_DEFAULT, skipBuilder = false) {
+    static create<T>(MetaClass: IType<T>, values: Partial<T>, transformType: ITransformType = TRANSFORM_TYPE_DEFAULT, skipBuilder = false): T {
         // Check empty
         if (values === null) {
             return null;

--- a/src/usecases/interfaces/ICrudRepository.ts
+++ b/src/usecases/interfaces/ICrudRepository.ts
@@ -1,13 +1,10 @@
-import {Repository} from '@steroidsjs/typeorm';
 import {SearchResultDto} from '../dtos/SearchResultDto';
 import {SearchInputDto} from '../dtos/SearchInputDto';
 import SearchQuery, {ISearchQueryConfig} from '../base/SearchQuery';
 import {ICondition} from '../../infrastructure/helpers/typeORM/ConditionHelperTypeORM';
-import {IType} from './IType';
 
 export interface ICrudRepository<TModel> {
-    dbRepository: Repository<any>;
-    search: <TItem>(dto: SearchInputDto, searchQuery: SearchQuery<TModel>) => Promise<SearchResultDto<TModel | IType<TItem>>>,
+    search: <TItem>(dto: SearchInputDto, searchQuery: SearchQuery<TModel>) => Promise<SearchResultDto<TModel | TItem>>,
     findOne: (conditionOrQuery: ICondition | SearchQuery<TModel>, eagerLoading?: boolean) => Promise<TModel | null>,
     findMany: (conditionOrQuery: ICondition | SearchQuery<TModel>, eagerLoading?: boolean) => Promise<TModel[]>,
     create: (model: TModel, transactionHandler?: (callback) => Promise<void>) => Promise<TModel>,

--- a/src/usecases/services/CrudService.ts
+++ b/src/usecases/services/CrudService.ts
@@ -207,6 +207,6 @@ export class CrudService<
         if (!this.modelClass) {
             throw new Error('Property modelClass is not set in service: ' + this.constructor.name);
         }
-        return DataMapper.create(this.modelClass, dto);
+        return DataMapper.create(this.modelClass, dto as any);
     }
 }

--- a/src/usecases/services/CrudService.ts
+++ b/src/usecases/services/CrudService.ts
@@ -12,13 +12,16 @@ import {IType} from '../interfaces/IType';
 /**
  * Generic CRUD service
  */
-export class CrudService<TModel,
+export class CrudService<
+    TModel,
     TSearchDto = ISearchInputDto,
-    TSaveDto = TModel> extends ReadService<TModel, TSearchDto>{
+    /** @deprecated */
+    TSaveDto = TModel
+> extends ReadService<TModel, TSearchDto> {
 
-    async create(dto: TSaveDto, context?: ContextDto | null): Promise<TModel>
+    async create(dto: Partial<TModel>, context?: ContextDto | null): Promise<TModel>
     async create<TSchema>(
-        dto: TSaveDto,
+        dto: Partial<TModel>,
         context?: ContextDto | null,
         schemaClass?: IType<TSchema>,
     ): Promise<IType<TSchema>>
@@ -30,20 +33,20 @@ export class CrudService<TModel,
      * @param schemaClass
      */
     async create<TSchema>(
-        dto: TSaveDto,
+        dto: Partial<TModel>,
         context: ContextDto = null,
         schemaClass: IType<TSchema> = null,
-    ): Promise<TModel | IType<TSchema>> {
+    ): Promise<TModel | TSchema> {
         return this.save(null, dto, context, schemaClass);
     }
 
-    async update<TSchema>(id: number | string, dto: TSaveDto, context?: ContextDto | null): Promise<TModel>
+    async update<TSchema>(id: number | string, dto: Partial<TModel>, context?: ContextDto | null): Promise<TModel>
     async update<TSchema>(
         id: number | string,
-        dto: TSaveDto,
+        dto: Partial<TModel>,
         context?: ContextDto | null,
         schemaClass?: IType<TSchema>,
-    ): Promise<IType<TSchema>>
+    ): Promise<TSchema>
 
     /**
      * Update model
@@ -54,20 +57,20 @@ export class CrudService<TModel,
      */
     async update<TSchema>(
         rawId: number | string,
-        dto: TSaveDto,
+        dto: Partial<TModel>,
         context: ContextDto = null,
         schemaClass: IType<TSchema> = null,
-    ): Promise<TModel | IType<TSchema>> {
+    ): Promise<TModel | TSchema> {
         return this.save(rawId, dto, context, schemaClass);
     }
 
-    async save<TSchema>(id: number | string, dto: TSaveDto, context?: ContextDto | null): Promise<TModel>
+    async save<TSchema>(id: number | string, dto: Partial<TModel>, context?: ContextDto | null): Promise<TModel>
     async save<TSchema>(
         id: number | string,
-        dto: TSaveDto,
+        dto: Partial<TModel>,
         context?: ContextDto | null,
         schemaClass?: IType<TSchema>,
-    ): Promise<IType<TSchema>>
+    ): Promise<TSchema>
 
     /**
      * Update model
@@ -78,10 +81,10 @@ export class CrudService<TModel,
      */
     async save<TSchema>(
         rawId: number | string | null,
-        dto: TSaveDto,
+        dto: Partial<TModel>,
         context: ContextDto = null,
         schemaClass: IType<TSchema> = null,
-    ): Promise<TModel | IType<TSchema>> {
+    ): Promise<TModel | TSchema> {
         const id: number = rawId ? _toInteger(rawId) : null;
 
         // Fetch previous model state
@@ -200,7 +203,7 @@ export class CrudService<TModel,
      * @param dto
      * @protected
      */
-    protected dtoToModel(dto: TSaveDto): TModel {
+    protected dtoToModel(dto: Partial<TModel>): TModel {
         if (!this.modelClass) {
             throw new Error('Property modelClass is not set in service: ' + this.constructor.name);
         }

--- a/src/usecases/services/CrudService.ts
+++ b/src/usecases/services/CrudService.ts
@@ -124,6 +124,13 @@ export class CrudService<
             context,
         });
 
+        // Validate by ModelClass
+        await this.validate(nextModel, {
+            prevModel,
+            nextModel,
+            context,
+        });
+
         // Save
         await this.saveInternal(prevModel, nextModel, context);
 

--- a/src/usecases/services/ReadService.ts
+++ b/src/usecases/services/ReadService.ts
@@ -45,7 +45,7 @@ export class ReadService<TModel, TSearchDto = ISearchInputDto> {
         dto: TSearchDto,
         context?: ContextDto | null,
         schemaClass?: IType<TSchema>
-    ): Promise<SearchResultDto<IType<TSchema>>>
+    ): Promise<SearchResultDto<TSchema>>
 
     /**
      * Search models with pagination, order and filters
@@ -57,7 +57,7 @@ export class ReadService<TModel, TSearchDto = ISearchInputDto> {
         dto: TSearchDto,
         context: ContextDto = null,
         schemaClass: IType<TSchema> = null
-    ): Promise<SearchResultDto<TModel | IType<TSchema>>> {
+    ): Promise<SearchResultDto<TModel | TSchema>> {
         await this.validate(dto, {
             context,
         });
@@ -89,7 +89,7 @@ export class ReadService<TModel, TSearchDto = ISearchInputDto> {
         id: number | string,
         context: ContextDto = null,
         schemaClass: IType<TSchema> = null,
-    ): Promise<TModel | IType<TSchema>> {
+    ): Promise<TModel | TSchema> {
         const searchQuery = schemaClass ? SearchQuery.createFromSchema<TModel>(schemaClass) : new SearchQuery<TModel>();
         searchQuery.andWhere({[this.primaryKey]: _toInteger(id)});
         const model = await this.findOne(searchQuery);
@@ -126,8 +126,8 @@ export class ReadService<TModel, TSearchDto = ISearchInputDto> {
      * @param schemaClass
      * @protected
      */
-    protected modelToSchema<TSchema>(model: TModel, schemaClass: IType<TSchema>): IType<TSchema> {
-        return DataMapper.create(schemaClass, model);
+    protected modelToSchema<TSchema>(model: TModel, schemaClass: IType<TSchema>): TSchema {
+        return DataMapper.create<any>(schemaClass, model);
     }
 
     protected async validate(dto: any, params?: IValidatorParams) {

--- a/src/usecases/services/ReadService.ts
+++ b/src/usecases/services/ReadService.ts
@@ -127,7 +127,7 @@ export class ReadService<TModel, TSearchDto = ISearchInputDto> {
      * @protected
      */
     protected modelToSchema<TSchema>(model: TModel, schemaClass: IType<TSchema>): TSchema {
-        return DataMapper.create<any>(schemaClass, model);
+        return DataMapper.create(schemaClass, model as any);
     }
 
     protected async validate(dto: any, params?: IValidatorParams) {


### PR DESCRIPTION
1. Исправлена типизация `DataMapper.create`

Было
```typescript
static create<T>(MetaClass: any values: Partial<T>, transformType: ITransformType = TRANSFORM_TYPE_DEFAULT, skipBuilder = false): any
```

Стало
```typescript
static create<T>(MetaClass: IType<T>, values: DeepPartial<T>, transformType: ITransformType = TRANSFORM_TYPE_DEFAULT, skipBuilder = false): T
```

2. `TSaveDto` в `CrudService` теперь deprecated, убраны его использования в методах `.create`, `.update`, `.save`
3. Исправлена типизация для методов поиска в `ReadService` с использованием `schemaClass` в качестве аргументов (в качестве результата был прописан `IType<TSchema>`, изменено на просто `TSchema`)
4. Изменен модификатор доступа `dbRepository` в _CrudRepository_ и _ICrudRepository_ с `public` на `protected`