### PR TITLE
add support for submodule migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/nest",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "scripts": {
     "script": "nps",
     "watch": "nps watch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/nest",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "scripts": {
     "script": "nps",
     "watch": "nps watch",


### PR DESCRIPTION
Столкнулся с проблемой накатывания миграций подмодулей `src/<ModuleName>/modules/<SubModuleName>/...`

`migrate:generate` отрабатывает стандартно (генерирует файлы миграции `src//modules//infrastructure/migrations...`), а вот migrate и `migrate:show` эти самые миграции не видят.