### PR TITLE
#6 Meta-class inheritance

### DIFF
--- a/src/infrastructure/decorators/fields/BaseField.ts
+++ b/src/infrastructure/decorators/fields/BaseField.ts
@@ -174,8 +174,7 @@ const ColumnMetaDecorator = (options: IBaseFieldOptions, internalOptions: IInter
     Reflect.defineMetadata(STEROIDS_META_FIELD_DECORATOR, internalOptions.decoratorName, object, propertyName);
 
     // Add field to list
-    const fieldNames = Reflect.getMetadata(STEROIDS_META_KEYS, object) || [];
-    fieldNames.push(propertyName);
+    const fieldNames = (Reflect.getMetadata(STEROIDS_META_KEYS, object) || []).concat(propertyName);
     Reflect.defineMetadata(STEROIDS_META_KEYS, fieldNames, object);
 };
 


### PR DESCRIPTION
```typescript
const fieldNames = Reflect.getMetadata(STEROIDS_META_KEYS, object) || [];
fieldNames.push(propertyName);
Reflect.defineMetadata(STEROIDS_META_KEYS, fieldNames, object);
```

В данном случае `Reflect.getMetadata` достаёт список метаданных прототипа объекта, и при первом вызове для родительского объекта метод вернёт `undefined`, который заменится на `[]`. Затем в этом массив добавится новый элемент, сохранятся метаданные и повторится этот цикл снова для других полей (понятное дело, что для следующих полей `Reflect.getMetadata` уже будет возвращать массив с данными, а не `undefined`).

Но если мы используем `Reflect.getMetadata` для дочернего класса, то он возьмет метаданные из прототипа, который будет ссылаться на класс родителя, то есть создания нового массива не происходит (если, конечно, у родительского класса есть метаданные). Затем мы используем 
мутабельный метод `push`, который изменит список и у родительского класса, так как в родительских и дочерних метаданных класса мы будем ссылаться на один массив.

Предлагаю просто использовать какой-нибудь иммутабельный способ добавления нового элемента в массив, который возвращает `Reflect.getMetadata(STEROIDS_META_KEYS, object)`:

```typescript
const fieldNames = (Reflect.getMetadata(STEROIDS_META_KEYS, object) || []).concat(propertyName);
Reflect.defineMetadata(STEROIDS_META_KEYS, fieldNames, object);
```

До:

![изображение](https://github.com/user-attachments/assets/8be376e6-7a24-4171-8b48-804f9fe898fa)

После:

![изображение](https://github.com/user-attachments/assets/a2c9cd59-1525-485c-aae4-023b82ee4dc2)