### PR TITLE
#46

### DIFF
--- a/src/usecases/services/CrudService.ts
+++ b/src/usecases/services/CrudService.ts
@@ -8,6 +8,7 @@ import {RelationTypeEnum} from '../../domain/enums/RelationTypeEnum';
 import {UserException} from '../exceptions';
 import {ReadService} from './ReadService';
 import {IType} from '../interfaces/IType';
+import {DeepPartial} from '@steroidsjs/typeorm';
 
 /**
  * Generic CRUD service
@@ -19,9 +20,9 @@ export class CrudService<
     TSaveDto = TModel
 > extends ReadService<TModel, TSearchDto> {
 
-    async create(dto: Partial<TModel>, context?: ContextDto | null): Promise<TModel>
+    async create(dto: DeepPartial<TModel>, context?: ContextDto | null): Promise<TModel>
     async create<TSchema>(
-        dto: Partial<TModel>,
+        dto: DeepPartial<TModel>,
         context?: ContextDto | null,
         schemaClass?: IType<TSchema>,
     ): Promise<IType<TSchema>>
@@ -33,17 +34,17 @@ export class CrudService<
      * @param schemaClass
      */
     async create<TSchema>(
-        dto: Partial<TModel>,
+        dto: DeepPartial<TModel>,
         context: ContextDto = null,
         schemaClass: IType<TSchema> = null,
     ): Promise<TModel | TSchema> {
         return this.save(null, dto, context, schemaClass);
     }
 
-    async update<TSchema>(id: number | string, dto: Partial<TModel>, context?: ContextDto | null): Promise<TModel>
+    async update<TSchema>(id: number | string, dto: DeepPartial<TModel>, context?: ContextDto | null): Promise<TModel>
     async update<TSchema>(
         id: number | string,
-        dto: Partial<TModel>,
+        dto: DeepPartial<TModel>,
         context?: ContextDto | null,
         schemaClass?: IType<TSchema>,
     ): Promise<TSchema>
@@ -57,17 +58,17 @@ export class CrudService<
      */
     async update<TSchema>(
         rawId: number | string,
-        dto: Partial<TModel>,
+        dto: DeepPartial<TModel>,
         context: ContextDto = null,
         schemaClass: IType<TSchema> = null,
     ): Promise<TModel | TSchema> {
         return this.save(rawId, dto, context, schemaClass);
     }
 
-    async save<TSchema>(id: number | string, dto: Partial<TModel>, context?: ContextDto | null): Promise<TModel>
+    async save<TSchema>(id: number | string, dto: DeepPartial<TModel>, context?: ContextDto | null): Promise<TModel>
     async save<TSchema>(
         id: number | string,
-        dto: Partial<TModel>,
+        dto: DeepPartial<TModel>,
         context?: ContextDto | null,
         schemaClass?: IType<TSchema>,
     ): Promise<TSchema>
@@ -83,7 +84,7 @@ export class CrudService<
      */
     async save<TSchema>(
         rawId: number | string | null,
-        dto: Partial<TModel>,
+        dto: DeepPartial<TModel>,
         context: ContextDto = null,
         schemaClass: IType<TSchema> = null,
     ): Promise<TModel | TSchema> {
@@ -250,7 +251,7 @@ export class CrudService<
      * @protected
      * @throws Error if modelClass is not set
      */
-    protected dtoToModel(dto: Partial<TModel>): TModel {
+    protected dtoToModel(dto: DeepPartial<TModel>): TModel {
         if (!this.modelClass) {
             throw new Error('Property modelClass is not set in service: ' + this.constructor.name);
         }


### PR DESCRIPTION
Изменены типы `Partial` на `DeepPartial` в `CrudService`, чтобы в методы можно было передавать `dto` с внутренними `dto`, которые соответствуют релейшенам у модели.