### PR TITLE
#225 feat: use getMetaRelationsFromObject in CrudService.save

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@steroidsjs/nest-typeorm": "^10.0.3",
     "@steroidsjs/typeorm": "^0.3.23",
     "@types/jest": "^29.4.0",
+    "@types/lodash": "^4.17.23",
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",

--- a/src/usecases/helpers/getAllObjectKeyPaths.ts
+++ b/src/usecases/helpers/getAllObjectKeyPaths.ts
@@ -1,0 +1,14 @@
+export function getAllObjectKeyPaths(
+    obj: Record<string, any>,
+    prefix = '',
+): string[] {
+    return Object.entries(obj).flatMap(([key, value]) => {
+        const keyPath = prefix
+            ? `${prefix}.${key}`
+            : key;
+
+        return typeof value === 'object' && value !== null && !Array.isArray(value)
+            ? [keyPath, ...getAllObjectKeyPaths(value, keyPath)]
+            : [keyPath];
+    });
+}

--- a/src/usecases/services/CrudService.ts
+++ b/src/usecases/services/CrudService.ts
@@ -4,7 +4,7 @@ import {DataMapper} from '../helpers/DataMapper';
 import {ISearchInputDto} from '../dtos/SearchInputDto';
 import SearchQuery from '../base/SearchQuery';
 import {ContextDto} from '../dtos/ContextDto';
-import {getMetaRelations, getRelationsByFilter} from '../../infrastructure/decorators/fields/BaseField';
+import {getMetaRelations, getMetaRelationsFromObject, getRelationsByFilter, isMetaClass} from '../../infrastructure/decorators/fields/BaseField';
 import {RelationTypeEnum} from '../../domain/enums/RelationTypeEnum';
 import {UserException} from '../exceptions';
 import {ReadService} from './ReadService';
@@ -97,8 +97,12 @@ export class CrudService<
         // Fetch previous model state
         let prevModel = null;
         if (id) {
+            const relationsNames = isMetaClass(dto.constructor)
+                ? getMetaRelations(dto.constructor)
+                : getMetaRelationsFromObject(dto, this.modelClass);
+
             prevModel = await this.createQuery()
-                .with(getMetaRelations(dto.constructor))
+                .with(relationsNames)
                 .where({[this.primaryKey]: id})
                 .one();
             if (!prevModel) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,6 +1394,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash@^4.17.23":
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.23.tgz#c1bb06db218acc8fc232da0447473fc2fb9d9841"
+  integrity sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==
+
 "@types/node@*":
   version "17.0.10"
   resolved "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz"


### PR DESCRIPTION
https://gitlab.kozhindev.com/steroids/steroids-nest/-/issues/225

Добавил функцию getMetaRelationsFromObject для поиска релейшенов из объекта, не являющегося метаклассом (без метаданных)

Брал за основу getMetaRelations, поэтому во вспомогающих функциях оставил это todo:

```
// Из-за этого кода возвращаются не все реляции в случаях, когда у одного MetaClass'а
// есть несколько реляций с одним и тем же классом (см. ImageDownloadSchema для примера)
// @todo нужно исправить этот баг, иначе реализовав кэширование уже обработанных классов
```

Пример работы:

<img width="370" height="219" alt="изображение" src="https://github.com/user-attachments/assets/699d4e1e-fb2d-4373-9728-710718af8e2e" />

<img width="277" height="437" alt="изображение" src="https://github.com/user-attachments/assets/15e588df-b68f-4cef-948c-8418cdb3017f" />

На примере видно, что мы для сохранения используем обычный объект, но при этом в prevModel подтягиваются нужные релейшены
