### PR TITLE
feat: #180 CreateDtoPipe itemMetatype param

### DIFF
--- a/docs/functionality/DataMapper.md
+++ b/docs/functionality/DataMapper.md
@@ -103,3 +103,37 @@ console.log(dto);
 //  fullName: 'Зубенко Михаил Петрович'
 //}
 ```
+
+## CreateDtoPipe
+
+В REST-приложении `RestApplication` по умолчанию подключает глобальный `CreateDtoPipe`.
+Он создает экземпляры DTO-классов из `body`, `query` и других параметров NestJS-контроллеров.
+Для классов со steroids fields pipe использует `DataMapper`, поэтому при создании объекта применяются field-трансформации.
+
+Для одиночного DTO дополнительная настройка не требуется:
+
+```ts
+@Post()
+create(@Body() dto: StoreSaveDto) {
+    // dto является экземпляром StoreSaveDto
+}
+```
+
+Если в `body` передается массив объектов, тип элемента массива нужно указать явно в локальном pipe.
+Это связано с тем, что TypeScript не сохраняет runtime-информацию о типе элементов `StoreSaveDto[]`,
+и глобальный pipe видит только `Array`.
+
+```ts
+import {CreateDtoPipe} from '@steroidsjs/nest/infrastructure/pipes/CreateDtoPipe';
+
+@Post('batch')
+createMany(
+    @Body(new CreateDtoPipe(StoreSaveDto))
+    dtos: StoreSaveDto[],
+) {
+    // dtos является массивом StoreSaveDto[]
+}
+```
+
+Глобальный `CreateDtoPipe` пропускает массив без изменений, если тип элемента не указан.
+Поэтому локальный pipe получает исходный массив и создает DTO для каждого элемента.

--- a/src/infrastructure/pipes/CreateDtoPipe.test.ts
+++ b/src/infrastructure/pipes/CreateDtoPipe.test.ts
@@ -1,0 +1,95 @@
+import {ArgumentMetadata} from '@nestjs/common';
+import {CreateDtoPipe} from './CreateDtoPipe';
+import {IntegerField, RelationField, StringField} from '../decorators/fields';
+
+class PipeNestedDto {
+    @IntegerField()
+    id: number;
+}
+
+class PipeDto {
+    @IntegerField()
+    id: number;
+
+    @StringField()
+    title: string;
+
+    @RelationField({
+        type: 'ManyToOne',
+        relationClass: () => PipeNestedDto,
+    })
+    nested: PipeNestedDto;
+}
+
+const createMetadata = (metatype: ArgumentMetadata['metatype']): ArgumentMetadata => ({
+    type: 'body',
+    metatype,
+    data: undefined,
+});
+
+describe('CreateDtoPipe', () => {
+    it('creates DTO instance for plain object', async () => {
+        const result = await new CreateDtoPipe().transform(
+            {
+                id: '10',
+                title: 'First',
+                nested: {
+                    id: '20',
+                },
+            },
+            createMetadata(PipeDto),
+        ) as PipeDto;
+
+        expect(result).toBeInstanceOf(PipeDto);
+        expect(result.id).toBe(10);
+        expect(result.title).toBe('First');
+        expect(result.nested).toBeInstanceOf(PipeNestedDto);
+        expect(result.nested.id).toBe(20);
+    });
+
+    it('does not transform array in global pipe when item metatype is unknown', async () => {
+        const value = [
+            {
+                id: '10',
+                title: 'First',
+            },
+        ];
+
+        const result = await new CreateDtoPipe().transform(value, createMetadata(Array));
+
+        expect(result).toBe(value);
+    });
+
+    it('creates DTO instances for array when item metatype is passed explicitly', async () => {
+        const globalPipe = new CreateDtoPipe();
+        const localPipe = new CreateDtoPipe(PipeDto);
+        const value = [
+            {
+                id: '10',
+                title: 'First',
+                nested: {
+                    id: '20',
+                },
+            },
+            {
+                id: '30',
+                title: 'Second',
+                nested: {
+                    id: '40',
+                },
+            },
+        ];
+
+        const valueAfterGlobalPipe = await globalPipe.transform(value, createMetadata(Array));
+        const result = await localPipe.transform(valueAfterGlobalPipe, createMetadata(Array)) as PipeDto[];
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toBeInstanceOf(PipeDto);
+        expect(result[0].id).toBe(10);
+        expect(result[0].nested).toBeInstanceOf(PipeNestedDto);
+        expect(result[0].nested.id).toBe(20);
+        expect(result[1]).toBeInstanceOf(PipeDto);
+        expect(result[1].id).toBe(30);
+        expect(result[1].nested.id).toBe(40);
+    });
+});

--- a/src/infrastructure/pipes/CreateDtoPipe.ts
+++ b/src/infrastructure/pipes/CreateDtoPipe.ts
@@ -8,7 +8,7 @@ import {IType} from '../../usecases/interfaces/IType';
 export class CreateDtoPipe implements PipeTransform<any> {
     constructor(private readonly itemMetatype?: IType) {}
 
-    async transform(value: unknown, metadata: ArgumentMetadata): Promise<any> {
+    async transform(value: unknown, metadata: ArgumentMetadata): Promise<unknown> {
         const metatype = this.itemMetatype || metadata.metatype;
 
         // pipe не знает тип элементов массива.

--- a/src/infrastructure/pipes/CreateDtoPipe.ts
+++ b/src/infrastructure/pipes/CreateDtoPipe.ts
@@ -2,15 +2,34 @@ import {ArgumentMetadata, Injectable, PipeTransform} from '@nestjs/common';
 import {DataMapper} from '../../usecases/helpers/DataMapper';
 import {isMetaClass} from '../decorators/fields/BaseField';
 import {plainToInstance} from 'class-transformer';
+import {IType} from '../../usecases/interfaces/IType';
 
 @Injectable()
 export class CreateDtoPipe implements PipeTransform<any> {
-    async transform(value: any, metadata: ArgumentMetadata): Promise<any> {
-        // Оставляем plainToInstance для конвертации значений 'false' -> false, '10' -> 10, ...
-        value = plainToInstance(metadata.metatype, value);
+    constructor(private readonly itemMetatype?: IType) {}
 
-        if (isMetaClass(metadata.metatype)) {
-            value = DataMapper.create(metadata.metatype, value);
+    async transform(value: unknown, metadata: ArgumentMetadata): Promise<any> {
+        const metatype = this.itemMetatype || metadata.metatype;
+
+        // pipe не знает тип элементов массива.
+        // Если он вызовет createDto(Array, value), то испортит value, поэтому value пропускается без изменений
+        if (!this.itemMetatype && metadata.metatype === Array) {
+            return value;
+        }
+
+        if (Array.isArray(value)) {
+            return value.map(item => this.createDto(metatype, item));
+        }
+
+        return this.createDto(metatype, value);
+    }
+
+    protected createDto(metatype: IType, value: unknown) {
+        // Оставляем plainToInstance для конвертации значений 'false' -> false, '10' -> 10, ...
+        value = plainToInstance(metatype, value);
+
+        if (isMetaClass(metatype)) {
+            value = DataMapper.create(metatype, value);
         }
 
         return value;


### PR DESCRIPTION
Так как проблема была в потере metatype, добавил возможность использования CreateDtoPipe в виде локального pipe с явным прокидыванием типа в конструктор

Пример использования: 

```ts
    async sendTestPush(
        @Body(new CreateDtoPipe(TestPushDto)) dto: TestPushDto[],
    ) {
        console.log(dto);
    }
    
    [ TestPushDto { title: 'string', body: 'string', payload: 'string' } ]
```