### PR TITLE
fix(crud): #245 add partial types to save methods and return full model from saveInternal

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,10 @@
         "@steroidsjs/eslint-config"
     ],
     "parser": "@typescript-eslint/parser",
+    "rules": {
+      "no-dupe-class-members": "off",
+      "@typescript-eslint/no-dupe-class-members": "error"
+    },
     "env": {
         "node": true
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Steroids Nest Changelog
 
+## Unreleased
+
+### Fixes
+- Уточнена типизация save-методов `CrudRepository`, а `CrudService.saveInternal` теперь возвращает полную модель после частичного сохранения.
+
 ## [4.4.0](https://github.com/steroids/nest/compare/4.3.0...4.4.0) (2026-05-14)
 
 [Migration guide](docs/MigrationGuide.md#440-2026-05-14)

--- a/src/infrastructure/repositories/CrudRepository.ts
+++ b/src/infrastructure/repositories/CrudRepository.ts
@@ -168,10 +168,24 @@ export class CrudRepository<TModel> implements ICrudRepository<TModel>, OnModule
      * @param transactionHandler
      * @deprecated Use save() method
      */
-    async update(id: number, model: TModel, transactionHandler?: TransactionHandler<TModel>): Promise<TModel> {
+    async update(
+        id: number,
+        model: DeepPartial<TModel>,
+        transactionHandler?: TransactionHandler<TModel | DeepPartial<TModel>>,
+    ): Promise<DeepPartial<TModel>> {
         model[this.primaryKey] = id;
         return this.save(model, transactionHandler);
     }
+
+    async save(
+        model: TModel,
+        transactionHandler?: TransactionHandler<TModel | DeepPartial<TModel>>,
+    ): Promise<TModel>
+
+    async save(
+        model: DeepPartial<TModel>,
+        transactionHandler?: TransactionHandler<TModel | DeepPartial<TModel>>,
+    ): Promise<DeepPartial<TModel>>
 
     /**
      * Create or update item
@@ -179,17 +193,20 @@ export class CrudRepository<TModel> implements ICrudRepository<TModel>, OnModule
      * @param transactionHandler
      */
     async save(
-        model: TModel,
-        transactionHandler?: TransactionHandler<TModel>,
-    ): Promise<TModel> {
-        const saver = async (manager: EntityManager, nextModel: TModel): Promise<TModel> => {
+        model: TModel | DeepPartial<TModel>,
+        transactionHandler?: TransactionHandler<TModel | DeepPartial<TModel>>,
+    ): Promise<TModel | DeepPartial<TModel>> {
+        const saver = async (
+            manager: EntityManager,
+            nextModel: TModel | DeepPartial<TModel>,
+        ): Promise<TModel | DeepPartial<TModel>> => {
             const entity = this.modelToEntity(nextModel);
             const newEntity = await manager.save(entity);
             return this.entityToModel(newEntity);
         };
 
         if (transactionHandler) {
-            return this.dbRepository.manager.transaction<TModel>(
+            return this.dbRepository.manager.transaction<TModel | DeepPartial<TModel>>(
                 async (manager) => transactionHandler(
                     async () => this.saveInternal(
                         {save: (nextModel) => saver(manager, nextModel)},
@@ -197,20 +214,29 @@ export class CrudRepository<TModel> implements ICrudRepository<TModel>, OnModule
                     ),
                 ),
             );
-        } else {
-            return this.saveInternal(
-                {save: (nextModel) => saver(this.dbRepository.manager, nextModel)},
-                model,
-            );
         }
+        return this.saveInternal(
+            {save: (nextModel) => saver(this.dbRepository.manager, nextModel)},
+            model,
+        );
     }
+
+    async saveInternal(manager: ISaveManager<TModel>, nextModel: TModel): Promise<TModel>
+
+    async saveInternal(
+        manager: ISaveManager<TModel>,
+        nextModel: DeepPartial<TModel>,
+    ): Promise<DeepPartial<TModel>>
 
     /**
      * Internal save method for overwrite in project
      * @param manager
      * @param nextModel
      */
-    async saveInternal(manager: ISaveManager<TModel>, nextModel: TModel): Promise<TModel> {
+    async saveInternal(
+        manager: ISaveManager<TModel>,
+        nextModel: TModel | DeepPartial<TModel>,
+    ): Promise<TModel | DeepPartial<TModel>> {
         return manager.save(nextModel);
     }
 

--- a/src/usecases/interfaces/ICrudRepository.ts
+++ b/src/usecases/interfaces/ICrudRepository.ts
@@ -1,3 +1,4 @@
+import {DeepPartial} from '@steroidsjs/typeorm';
 import {SearchResultDto} from '../dtos/SearchResultDto';
 import {SearchInputDto} from '../dtos/SearchInputDto';
 import SearchQuery, {ISearchQueryConfig} from '../base/SearchQuery';
@@ -12,8 +13,19 @@ export interface ICrudRepository<TModel> {
     create: (model: TModel, transactionHandler?: TransactionHandler<TModel>) => Promise<TModel>,
     createQuery: (config?: ISearchQueryConfig<TModel>) => SearchQuery<TModel>,
     remove: (id: number, transactionHandler?: (callback) => Promise<void>) => Promise<void>,
-    save: (model: TModel, transactionHandler?: TransactionHandler<TModel>) => Promise<TModel>,
+    save(
+        model: TModel,
+        transactionHandler?: TransactionHandler<TModel | DeepPartial<TModel>>,
+    ): Promise<TModel>,
+    save(
+        model: DeepPartial<TModel>,
+        transactionHandler?: TransactionHandler<TModel | DeepPartial<TModel>>,
+    ): Promise<DeepPartial<TModel>>,
     softRemove: (id: number, transactionHandler?: (callback: () => Promise<void>) => Promise<void>) => Promise<void>,
-    update: (id: number, model: TModel, transactionHandler?: TransactionHandler<TModel>) => Promise<TModel>
+    update: (
+        id: number,
+        model: DeepPartial<TModel>,
+        transactionHandler?: TransactionHandler<TModel | DeepPartial<TModel>>,
+    ) => Promise<DeepPartial<TModel>>,
     isExistsById: (id: number) => Promise<boolean>,
 }

--- a/src/usecases/interfaces/ISaveManager.ts
+++ b/src/usecases/interfaces/ISaveManager.ts
@@ -1,3 +1,5 @@
-export interface ISaveManager<TModel>{
-    save: (model) => Promise<TModel>,
+import {DeepPartial} from '@steroidsjs/typeorm';
+
+export interface ISaveManager<TModel> {
+    save: (model: TModel | DeepPartial<TModel>) => Promise<TModel | DeepPartial<TModel>>,
 }

--- a/src/usecases/services/CrudService.ts
+++ b/src/usecases/services/CrudService.ts
@@ -154,6 +154,20 @@ export class CrudService<
             : savedModel;
     }
 
+    async saveInternal(
+        prevModel: TModel,
+        nextModel: TModel,
+        diffModel: DeepPartial<TModel>,
+        context?: ContextDto,
+    ): Promise<TModel>
+
+    async saveInternal(
+        prevModel: null,
+        nextModel: TModel,
+        diffModel: TModel,
+        context?: ContextDto,
+    ): Promise<TModel>
+
     /**
      * Internal save method for overwrite in project
      * @param prevModel
@@ -161,7 +175,12 @@ export class CrudService<
      * @param diffModel
      * @param context
      */
-    async saveInternal(prevModel: TModel | null, nextModel: TModel, diffModel: TModel, context?: ContextDto): Promise<TModel> {
+    async saveInternal(
+        prevModel: TModel | null,
+        nextModel: TModel,
+        diffModel: DeepPartial<TModel>,
+        context?: ContextDto,
+    ): Promise<TModel> {
         // you code outside transaction before save
         // return this.repository.save(diffModel, async (save) => {
             // you code inside transaction before save
@@ -172,7 +191,12 @@ export class CrudService<
         // you code outside transaction after save
 
         // or save() call without transaction
-        return this.repository.save(diffModel);
+        if (prevModel) {
+            const savedModel = await this.repository.save(diffModel);
+            return this.findById(savedModel[this.primaryKey], context);
+        }
+
+        return this.repository.save(nextModel);
     }
 
     /**


### PR DESCRIPTION
https://gitlab.kozhindev.com/steroids/steroids-nest/-/work_items/245

Уточнена типизация save-методов `CrudRepository`, а `CrudService.saveInternal` теперь возвращает полную модель после частичного сохранения