### PR TITLE
feat: #134 types for SearchQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Steroids Nest Changelog
 
+## Unreleased
+
+[Migration guide](docs/MigrationGuide.md#Unreleased)
+
+### Features
+- Добавлена типизация для методов `SearchQuery`: IDE подсказывает поля модели и dot-path до глубины равной 5 ([#134](https://gitlab.kozhindev.com/steroids/steroids-nest/-/work_items/134)).
+
 ## [4.4.0](https://github.com/steroids/nest/compare/4.3.0...4.4.0) (2026-05-14)
 
 [Migration guide](docs/MigrationGuide.md#440-2026-05-14)

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -1,5 +1,36 @@
 # Steroids Nest Migration Guide
 
+## Unreleased
+
+### Типизация `SearchQuery`
+
+`SearchQuery` получил типизированные аргументы для `select`, `excludeSelect`, `with`, `where` и `orderBy`-методов. Runtime-поведение не менялось: старые строковые пути, alias вида `model.timeFrom` и вручную собранные условия продолжают поддерживаться.
+
+Чтобы получить подсказки, `SearchQuery` должен знать тип модели. Обычно это происходит автоматически при вызове `createQuery()` из типизированного `CrudService`/`ReadService`.
+Если `SearchQuery` создаётся вручную, передайте generic:
+
+Что стоит проверить в проекте:
+
+- В `orderBy` лучше использовать путь без корневого alias, например `orderBy('timeFrom')`. Варианты вроде `orderBy('model.timeFrom')` оставлены валидными для совместимости.
+- В `with` подсказки строятся по relation-like полям: объект или массив объектов с полем `id`, а также поля с суффиксом `Id`/`Ids`. JSON-поля без `id` не попадают в подсказки `with`, но произвольная строка всё ещё принимается для обратной совместимости.
+- Dot-path подсказки ограничены глубиной 5. Более глубокие пути можно передать строкой вручную, но они не будут частью строгих подсказок.
+- Условия, которые собираются через `map` и spread. TypeScript может вывести обычный массив вместо tuple-условия. В таком случае вынесите результат в переменную с явным типом:
+
+```ts
+import type {ISearchQueryWhere} from '@steroidsjs/nest/usecases/base/SearchQuery';
+
+const timeConditions: ISearchQueryWhere<ShiftModel>[] = dto.items.map((item) => [
+    'and',
+    ['<', 'timeFrom', item.timeTo],
+    ['>', 'timeTo', item.timeFrom],
+]);
+
+await this.shiftService.createQuery()
+    .where(['=', 'courierId', dto.courierId])
+    .andWhere(['or', ...timeConditions])
+    .many();
+```
+
 ## [4.4.0](../CHANGELOG.md#440-2026-05-14) (2026-05-14)
 
 ### Добавление `RestApplication.initCookieParser`

--- a/src/infrastructure/helpers/typeORM/ConditionHelperTypeORM.ts
+++ b/src/infrastructure/helpers/typeORM/ConditionHelperTypeORM.ts
@@ -10,19 +10,14 @@ import {QueryAdapterTypeORM} from '../../adapters/QueryAdapterTypeORM';
 import SearchQuery from '../../../usecases/base/SearchQuery';
 import {getMetaPrimaryKey} from '../../decorators/fields/BaseField';
 import {ObjectToArray} from '../../../usecases/helpers/ObjectToArray';
+import type {ICondition} from '../../../usecases/interfaces/searchQuery/ISearchQueryWhere';
 
-export type IConditionOperatorSingle = '=' | '>' | '>=' | '=>' | '<' | '<=' | '=<' | 'like' | 'ilike' | 'between'
-    | 'in' | 'and' | '&&' | 'or' | '||' | 'not =' | 'not >' | 'not >=' | 'not =>' | 'not <' | 'not <=' | 'not =<'
-    | 'not like' | 'not ilike' | 'not between' | 'not in' | 'not and' | 'not &&' | 'not or' | 'not ||' | '@>'
-    | 'not @>' | '<@' | 'not <@' | 'overlap' | 'not overlap';
-export type IConditionOperatorAndOr = 'and' | '&&' | 'or' | '||' | 'not and' | 'not &&' | 'not or' | 'not ||';
-export type IConditionOperatorSubquery = 'some' | 'every' | 'none';
-export type ICondition = Record<string, unknown>
-    | [IConditionOperatorAndOr, ...any[]]
-    | ['filter', ICondition]
-    | [IConditionOperatorSingle, string, ...any[]]
-    | [IConditionOperatorSubquery, string | string[], ICondition]
-    | ICondition[];
+export type {
+    ICondition,
+    IConditionOperatorAndOr,
+    IConditionOperatorSingle,
+    IConditionOperatorSubquery,
+} from '../../../usecases/interfaces/searchQuery/ISearchQueryWhere';
 
 const emptyCondition = {};
 const isEmpty = value => value === null || typeof value === 'undefined' || value === emptyCondition || value === '';

--- a/src/usecases/base/SearchQuery.ts
+++ b/src/usecases/base/SearchQuery.ts
@@ -2,8 +2,11 @@ import {trim as _trim} from 'lodash';
 import {createHash} from 'crypto';
 import {getSchemaSelectOptions} from '../../infrastructure/decorators/schema/SchemaSelect';
 import {getMetaRelations} from '../../infrastructure/decorators/fields/BaseField';
-import {ICondition} from '../../infrastructure/helpers/typeORM/ConditionHelperTypeORM';
 import {wrapInDoubleQuotes} from '../utils/wrapInDoubleQuotes';
+import {ISearchQuerySelect} from '../interfaces/searchQuery/ISearchQuerySelect';
+import {ISearchQueryOrder, ISearchQueryOrderField, ISearchQueryOrderValue} from '../interfaces/searchQuery/ISearchQueryOrder';
+import {ISearchQueryRelationOptions, ISearchQueryWithValue} from '../interfaces/searchQuery/ISearchQueryWith';
+import {ISearchQueryWhere} from '../interfaces/searchQuery/ISearchQueryWhere';
 
 /**
  * Order keys can be:
@@ -14,9 +17,32 @@ import {wrapInDoubleQuotes} from '../utils/wrapInDoubleQuotes';
  *
  * Field path parts can already be wrapped in double quotes.
  */
-export type ISearchQueryOrder = { [key: string]: 'asc' | 'desc' }
-
 export const DEFAULT_ALIAS = 'model';
+
+export type {
+    ISearchQueryOrder,
+    ISearchQueryOrderDirection,
+    ISearchQueryOrderField,
+    ISearchQueryOrderInput,
+    ISearchQueryOrderValue,
+} from '../interfaces/searchQuery/ISearchQueryOrder';
+export type {
+    ISearchQueryRelationOptions,
+    ISearchQueryWithRelation,
+    ISearchQueryWithRelationPath,
+    ISearchQueryWithRelations,
+    ISearchQueryWithSelect,
+    ISearchQueryWithValue,
+} from '../interfaces/searchQuery/ISearchQueryWith';
+export type {
+    IConditionOperatorAndOr,
+    IConditionOperatorSingle,
+    IConditionOperatorSubquery,
+    ISearchQueryWhere,
+    ISearchQueryWhereField,
+    ISearchQueryWhereObject,
+    ISearchQueryWhereRelation,
+} from '../interfaces/searchQuery/ISearchQueryWhere';
 
 const ALIAS_HASH_LENGTH = 16;
 
@@ -27,24 +53,30 @@ export interface ISearchQueryConfig<TModel> {
 }
 
 export default class SearchQuery<TModel> {
-    protected _select?: string[];
-    protected _excludeSelect?: string[];
+    protected _select?: ISearchQuerySelect<TModel>[];
+
+    protected _excludeSelect?: ISearchQuerySelect<TModel>[];
+
     protected _alias?: string;
-    protected _relationsJoin?: Record<string, {
-        alias: string,
-        select: string | string[],
-    }>;
-    protected _relationsNoJoin?: Record<string, {
-        alias: string,
-        select: string | string[],
-    }>;
-    protected _condition?: ICondition;
-    protected _orders?: ISearchQueryOrder;
+
+    protected _relationsJoin?: Record<string, ISearchQueryRelationOptions>;
+
+    protected _relationsNoJoin?: Record<string, ISearchQueryRelationOptions>;
+
+    protected _condition?: ISearchQueryWhere<TModel>;
+
+    protected _orders?: ISearchQueryOrder<TModel>;
+
     protected _limit?: number;
+
     protected _offset?: number;
+
     protected _useShortAliases: boolean;
+
     protected _withDeleted: boolean;
+
     protected _onGetOne: ISearchQueryConfig<TModel>['onGetOne'];
+
     protected _onGetMany: ISearchQueryConfig<TModel>['onGetMany'];
 
     constructor(config?: ISearchQueryConfig<TModel>) {
@@ -65,7 +97,7 @@ export default class SearchQuery<TModel> {
             [value]: {
                 alias: null,
                 select: '*',
-            }
+            },
         }), {});
 
         return searchQuery;
@@ -94,12 +126,12 @@ export default class SearchQuery<TModel> {
                 .slice(0, ALIAS_HASH_LENGTH);
     }
 
-    select(value: string | string[]) {
+    select(value: ISearchQuerySelect<TModel> | ISearchQuerySelect<TModel>[]) {
         this._select = [].concat(value || []);
         return this;
     }
 
-    addSelect(value: string | string[]) {
+    addSelect(value: ISearchQuerySelect<TModel> | ISearchQuerySelect<TModel>[]) {
         this._select = [
             ...this._select,
             ...[].concat(value || []),
@@ -111,7 +143,7 @@ export default class SearchQuery<TModel> {
         return this._select;
     }
 
-    excludeSelect(value: string | string[]) {
+    excludeSelect(value: ISearchQuerySelect<TModel> | ISearchQuerySelect<TModel>[]) {
         this._excludeSelect = [].concat(value || []);
         return this;
     }
@@ -145,15 +177,13 @@ export default class SearchQuery<TModel> {
         return this._useShortAliases;
     }
 
-    with(relation: Record<string, string | string[]> | string | string[], useJoin = true) {
+    with(relation: ISearchQueryWithValue<TModel>, useJoin = true) {
         if (useJoin) {
             if (!this._relationsJoin) {
                 this._relationsJoin = {};
             }
-        } else {
-            if (!this._relationsNoJoin) {
-                this._relationsNoJoin = {};
-            }
+        } else if (!this._relationsNoJoin) {
+            this._relationsNoJoin = {};
         }
 
         const relations = useJoin ? this._relationsJoin : this._relationsNoJoin;
@@ -207,7 +237,7 @@ export default class SearchQuery<TModel> {
         return this;
     }
 
-    withNoJoin(relation: Record<string, string | string[]> | string | string[]) {
+    withNoJoin(relation: ISearchQueryWithValue<TModel>) {
         return this.with(relation, false);
     }
 
@@ -228,16 +258,16 @@ export default class SearchQuery<TModel> {
         return this._relationsNoJoin;
     }
 
-    where(condition: ICondition) {
+    where(condition: ISearchQueryWhere<TModel>) {
         this._condition = condition;
         return this;
     }
 
-    filterWhere(condition: ICondition) {
+    filterWhere(condition: ISearchQueryWhere<TModel>) {
         return this.where(['filter', condition]);
     }
 
-    andWhere(condition: ICondition) {
+    andWhere(condition: ISearchQueryWhere<TModel>) {
         if (this._condition) {
             this._condition = [
                 'and',
@@ -245,16 +275,15 @@ export default class SearchQuery<TModel> {
                 condition,
             ];
             return this;
-        } else {
-            return this.where(condition);
         }
+        return this.where(condition);
     }
 
-    andFilterWhere(condition: ICondition) {
+    andFilterWhere(condition: ISearchQueryWhere<TModel>) {
         return this.andWhere(['filter', condition]);
     }
 
-    orWhere(condition: ICondition) {
+    orWhere(condition: ISearchQueryWhere<TModel>) {
         if (this._condition) {
             this._condition = [
                 'or',
@@ -262,12 +291,11 @@ export default class SearchQuery<TModel> {
                 condition,
             ];
             return this;
-        } else {
-            return this.where(condition);
         }
+        return this.where(condition);
     }
 
-    orFilterWhere(condition: ICondition) {
+    orFilterWhere(condition: ISearchQueryWhere<TModel>) {
         return this.orWhere(['filter', condition]);
     }
 
@@ -275,7 +303,7 @@ export default class SearchQuery<TModel> {
         return this._condition;
     }
 
-    private resolveOrderByFieldPath(fieldPath: string): string {
+    private resolveOrderByFieldPath(fieldPath: ISearchQueryOrderField<TModel>): string {
         const pathToField = fieldPath.split('.');
         const field = pathToField.pop();
 
@@ -298,9 +326,9 @@ export default class SearchQuery<TModel> {
     }
 
     private resolveOrderByFieldPaths(
-        orderValue: string | ISearchQueryOrder,
+        orderValue: ISearchQueryOrderValue<TModel>,
         direction: 'asc' | 'desc',
-    ): ISearchQueryOrder {
+    ): ISearchQueryOrder<TModel> {
         if (typeof orderValue === 'string') {
             return {
                 [this.resolveOrderByFieldPath(orderValue)]: direction,
@@ -313,12 +341,12 @@ export default class SearchQuery<TModel> {
         }), {});
     }
 
-    orderBy(value: string | ISearchQueryOrder, direction: 'asc' | 'desc' = 'asc') {
+    orderBy(value: ISearchQueryOrderValue<TModel>, direction: 'asc' | 'desc' = 'asc') {
         this._orders = this.resolveOrderByFieldPaths(value, direction);
         return this;
     }
 
-    addOrderBy(value: string | ISearchQueryOrder, direction: 'asc' | 'desc' = 'asc') {
+    addOrderBy(value: ISearchQueryOrderValue<TModel>, direction: 'asc' | 'desc' = 'asc') {
         this._orders = {
             ...this._orders,
             ...this.resolveOrderByFieldPaths(value, direction),
@@ -364,7 +392,7 @@ export default class SearchQuery<TModel> {
         throw new Error('[@steroidsjs/nest] SearchQuery do not support one() method. Provide _onGetOne param in config');
     }
 
-    async many(eagerLoading: boolean = true) {
+    async many(eagerLoading = true) {
         if (this._onGetMany) {
             return this._onGetMany(this);
         }

--- a/src/usecases/base/SearchQuery.types.test.ts
+++ b/src/usecases/base/SearchQuery.types.test.ts
@@ -1,0 +1,157 @@
+import {describe, expect, it} from '@jest/globals';
+import SearchQuery from './SearchQuery';
+import {ISearchQueryWithRelationPath} from '../interfaces/searchQuery/ISearchQueryWith';
+
+class RegionModel {
+    id: number;
+
+    name: string;
+}
+
+class CountryModel {
+    id: number;
+
+    region: RegionModel;
+}
+
+class ProfileModel {
+    id: number;
+
+    city: string;
+
+    country: CountryModel;
+}
+
+class CustomerModel {
+    id: number;
+
+    name: string;
+
+    profileId: number;
+
+    profile: ProfileModel;
+}
+
+class OrderItemModel {
+    id: number;
+
+    title: string;
+}
+
+class OrderModel {
+    id: number;
+
+    status: string;
+
+    customerId: number;
+
+    customer: CustomerModel;
+
+    items: OrderItemModel[];
+
+    payload: {
+        source: string,
+        metadata: {
+            code: string,
+        },
+    };
+}
+
+describe('SearchQuery type helpers', () => {
+    it('accepts model fields for select methods', () => {
+        const searchQuery = new SearchQuery<OrderModel>();
+
+        searchQuery
+            .select(['id', 'status'])
+            .addSelect('customerId')
+            .excludeSelect('status');
+
+        expect(searchQuery.getSelect()).toEqual(['id', 'status', 'customerId']);
+        expect(searchQuery.getExcludeSelect()).toEqual(['status']);
+    });
+
+    it('accepts model paths for orderBy methods', () => {
+        const searchQuery = new SearchQuery<OrderModel>();
+
+        searchQuery
+            .orderBy('customer.profile.city', 'desc')
+            .addOrderBy({
+                status: 'asc',
+                'items.title': 'desc',
+                'customer.profile.country.region.name': 'asc',
+            });
+
+        expect(searchQuery.getOrderBy()).toEqual({
+            '"model_customer_profile"."city"': 'desc',
+            '"model"."status"': 'asc',
+            '"model_items"."title"': 'desc',
+            '"model_customer_profile_country_region"."name"': 'asc',
+        });
+    });
+
+    it('accepts relation paths for with methods', () => {
+        const searchQuery = new SearchQuery<OrderModel>();
+
+        searchQuery
+            .with(['customer', 'customer.profile', 'customer.profile.country.region', 'customerId'])
+            .with({
+                items: ['id', 'title'],
+            })
+            .withNoJoin(['items']);
+
+        expect(searchQuery.getWith()).toEqual([
+            'customer',
+            'customer.profile',
+            'customer.profile.country',
+            'customer.profile.country.region',
+            'customerId',
+            'items',
+        ]);
+        expect(searchQuery.getWithNoJoin()).toEqual({
+            items: {
+                alias: null,
+                select: '*',
+            },
+        });
+    });
+
+    it('does not include JSON objects in with relation path suggestions', () => {
+        const customerRelation: ISearchQueryWithRelationPath<OrderModel> = 'customer';
+        const nestedCustomerRelation: ISearchQueryWithRelationPath<OrderModel> = 'customer.profile';
+        const deepCustomerRelation: ISearchQueryWithRelationPath<OrderModel> = 'customer.profile.country.region';
+
+        // @ts-expect-error JSON object fields should not be suggested as relation paths.
+        const payloadRelation: ISearchQueryWithRelationPath<OrderModel> = 'payload';
+        // @ts-expect-error Nested JSON object fields should not be suggested as relation paths.
+        const nestedPayloadRelation: ISearchQueryWithRelationPath<OrderModel> = 'payload.metadata';
+
+        expect(customerRelation).toEqual('customer');
+        expect(nestedCustomerRelation).toEqual('customer.profile');
+        expect(deepCustomerRelation).toEqual('customer.profile.country.region');
+        expect(payloadRelation).toEqual('payload');
+        expect(nestedPayloadRelation).toEqual('payload.metadata');
+    });
+
+    it('accepts model paths for where methods', () => {
+        const searchQuery = new SearchQuery<OrderModel>();
+
+        searchQuery
+            .where(['=', 'customer.profile.city', 'Krasnoyarsk'])
+            .andWhere(['=', 'customer.profile.country.region.name', 'Siberia'])
+            .andWhere({
+                status: 'created',
+                customer: {
+                    profile: {
+                        city: 'Krasnoyarsk',
+                    },
+                },
+            })
+            .orWhere(['some', 'items', ['like', 'items.title', 'book']])
+            .filterWhere(['in', 'customerId', [1, 2]]);
+
+        expect(searchQuery.getWhere()).toEqual([
+            'filter',
+            ['in', 'customerId', [1, 2]],
+        ]);
+    });
+});

--- a/src/usecases/interfaces/searchQuery/ISearchQueryOrder.ts
+++ b/src/usecases/interfaces/searchQuery/ISearchQueryOrder.ts
@@ -1,0 +1,21 @@
+import {IsNestedValue, LiteralUnion, PreviousDepth, Primitive, Unpacked} from './helpers';
+
+type SearchQueryOrderFieldPath<TModel, TDepth extends number = 5> =
+    [TDepth] extends [0]
+        ? never
+        : TModel extends Primitive | Date | Function | Buffer
+            ? never
+            : {
+                [TKey in keyof TModel & string]:
+                | TKey
+                | (IsNestedValue<TModel[TKey]> extends true
+                    ? `${TKey}.${SearchQueryOrderFieldPath<Unpacked<TModel[TKey]>, PreviousDepth[TDepth] & number>}`
+                    : never)
+            }[keyof TModel & string];
+
+export type ISearchQueryOrderDirection = 'asc' | 'desc';
+export type ISearchQueryOrderField<TModel> = LiteralUnion<SearchQueryOrderFieldPath<TModel>>;
+export type ISearchQueryOrder<TModel = any> = Record<string, ISearchQueryOrderDirection>;
+export type ISearchQueryOrderInput<TModel> = ISearchQueryOrder<TModel>
+    & Partial<Record<SearchQueryOrderFieldPath<TModel>, ISearchQueryOrderDirection>>;
+export type ISearchQueryOrderValue<TModel> = ISearchQueryOrderField<TModel> | ISearchQueryOrderInput<TModel>;

--- a/src/usecases/interfaces/searchQuery/ISearchQuerySelect.ts
+++ b/src/usecases/interfaces/searchQuery/ISearchQuerySelect.ts
@@ -1,0 +1,3 @@
+import {LiteralUnion} from './helpers';
+
+export type ISearchQuerySelect<TModel> = LiteralUnion<keyof TModel & string>;

--- a/src/usecases/interfaces/searchQuery/ISearchQueryWhere.ts
+++ b/src/usecases/interfaces/searchQuery/ISearchQueryWhere.ts
@@ -1,0 +1,42 @@
+import {ISearchQueryWithRelation} from './ISearchQueryWith';
+import {IsNestedValue, LiteralUnion, PreviousDepth, Primitive, Unpacked} from './helpers';
+
+type SearchQueryWhereFieldPath<TModel, TDepth extends number = 5> =
+    [TDepth] extends [0]
+        ? never
+        : TModel extends Primitive | Date | Function | Buffer
+            ? never
+            : {
+                [TKey in keyof TModel & string]:
+                | TKey
+                | (IsNestedValue<TModel[TKey]> extends true
+                    ? `${TKey}.${SearchQueryWhereFieldPath<Unpacked<TModel[TKey]>, PreviousDepth[TDepth] & number>}`
+                    : never)
+            }[keyof TModel & string];
+
+export type IConditionOperatorSingle = '=' | '>' | '>=' | '=>' | '<' | '<=' | '=<' | 'like' | 'ilike' | 'between'
+    | 'in' | 'and' | '&&' | 'or' | '||' | 'not =' | 'not >' | 'not >=' | 'not =>' | 'not <' | 'not <=' | 'not =<'
+    | 'not like' | 'not ilike' | 'not between' | 'not in' | 'not and' | 'not &&' | 'not or' | 'not ||' | '@>'
+    | 'not @>' | '<@' | 'not <@' | 'overlap' | 'not overlap';
+export type IConditionOperatorAndOr = 'and' | '&&' | 'or' | '||' | 'not and' | 'not &&' | 'not or' | 'not ||';
+export type IConditionOperatorSubquery = 'some' | 'every' | 'none';
+export type ICondition = Record<string, unknown>
+    | [IConditionOperatorAndOr, ...any[]]
+    | ['filter', ICondition]
+    | [IConditionOperatorSingle, string, ...any[]]
+    | [IConditionOperatorSubquery, string | string[], ICondition]
+    | ICondition[];
+
+export type ISearchQueryWhereField<TModel> = LiteralUnion<SearchQueryWhereFieldPath<TModel>>;
+export type ISearchQueryWhereObject<TModel> =
+    | Partial<Record<ISearchQueryWhereField<TModel>, unknown>>
+    | Record<string, unknown>;
+export type ISearchQueryWhereRelation<TModel> = ISearchQueryWithRelation<TModel>
+    | ISearchQueryWithRelation<TModel>[];
+export type ISearchQueryWhere<TModel = any> =
+    | ISearchQueryWhereObject<TModel>
+    | [IConditionOperatorAndOr, ...ISearchQueryWhere<TModel>[]]
+    | ['filter', ISearchQueryWhere<TModel>]
+    | [IConditionOperatorSingle, ISearchQueryWhereField<TModel>, ...unknown[]]
+    | [IConditionOperatorSubquery, ISearchQueryWhereRelation<TModel>, ISearchQueryWhere<TModel>]
+    | ISearchQueryWhere<TModel>[];

--- a/src/usecases/interfaces/searchQuery/ISearchQueryWith.ts
+++ b/src/usecases/interfaces/searchQuery/ISearchQueryWith.ts
@@ -1,0 +1,31 @@
+import {IsRelationValue, LiteralUnion, PreviousDepth, Primitive, Unpacked} from './helpers';
+
+type RelationIdField<TModel> = keyof TModel & (`${string}Id` | `${string}Ids`);
+
+type SearchQueryRelationPath<TModel, TDepth extends number = 5> =
+    [TDepth] extends [0]
+        ? never
+        : TModel extends Primitive | Date | Function | Buffer
+            ? never
+            : {
+                [TKey in keyof TModel & string]:
+                | (TKey extends RelationIdField<TModel> ? TKey : never)
+                | (IsRelationValue<TModel[TKey]> extends true
+                    ? TKey | `${TKey}.${SearchQueryRelationPath<Unpacked<TModel[TKey]>, PreviousDepth[TDepth] & number>}`
+                    : never)
+            }[keyof TModel & string];
+
+export type ISearchQueryWithSelect = string | string[];
+export type ISearchQueryWithRelationPath<TModel> = SearchQueryRelationPath<TModel>;
+export type ISearchQueryWithRelation<TModel> = LiteralUnion<
+    ISearchQueryWithRelationPath<TModel> | `${ISearchQueryWithRelationPath<TModel>} ${string}`
+>;
+export type ISearchQueryWithRelations<TModel> = Record<string, ISearchQueryWithSelect>
+    & Partial<Record<ISearchQueryWithRelationPath<TModel>, ISearchQueryWithSelect>>;
+export type ISearchQueryWithValue<TModel> = ISearchQueryWithRelation<TModel>
+    | ISearchQueryWithRelation<TModel>[]
+    | ISearchQueryWithRelations<TModel>;
+export type ISearchQueryRelationOptions = {
+    alias: string,
+    select: ISearchQueryWithSelect,
+};

--- a/src/usecases/interfaces/searchQuery/helpers/index.ts
+++ b/src/usecases/interfaces/searchQuery/helpers/index.ts
@@ -1,0 +1,9 @@
+export type Primitive = string | number | boolean | bigint | symbol | null | undefined;
+export type LiteralUnion<TLiteral extends TBase, TBase = string> = TLiteral | (TBase & Record<never, never>);
+export type PreviousDepth = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+export type Unpacked<TValue> = TValue extends Array<infer TItem> ? NonNullable<TItem> : NonNullable<TValue>;
+export type IsNestedValue<TValue> = Unpacked<TValue> extends Primitive | Date | Function | Buffer ? false : true;
+export type IsRelationValue<TValue> =
+    Unpacked<TValue> extends Primitive | Date | Function | Buffer
+        ? false
+        : 'id' extends keyof Unpacked<TValue> ? true : false;


### PR DESCRIPTION
https://gitlab.kozhindev.com/steroids/steroids-nest/-/work_items/134

Добавлена типизация для методов `SearchQuery`: IDE подсказывает поля модели и dot-path до глубины равной 5